### PR TITLE
Label EML output as created with EMLassemblyline

### DIFF
--- a/R/make_eml.R
+++ b/R/make_eml.R
@@ -1357,13 +1357,19 @@ make_eml <- function(
   }
   
   # Create <additionalMetadata> -----------------------------------------------
-  
   if (!is.null(x$template$custom_units.txt)) {
     message("  <additionalMetadata>")
     eml$additionalMetadata[[
       length(eml$dataset$additionalMetadata)+1]]$metadata$unitList <- EML::set_unitList(
         x$template$custom_units.txt$content)
   }
+
+  message("  <additionalMetadata>")
+  eml$additionalMetadata[[
+    length(eml$additionalMetadata)+1]] <- EML::eml$additionalMetadata(
+      metadata = list(emlEditor = list(
+        "app" = "EMLassemblyline",
+        "release" = read.dcf(system.file("DESCRIPTION", package = "EMLassemblyline"))[[3]])))
   
   # Create <annotations> ------------------------------------------------------
 


### PR DESCRIPTION
To track that the final EML/XML document was created using EMLassemblyline, we can add an additionalMetadata block that lists the app and version of the app used to create. Useful for meta analysis down the line.

Something very similar is used in ezEML, though this implementation creates an emlEditor element with children app and release whereas ezEML creates an emlEditor element with attributes app and release.