### PR TITLE
Fix GH Action dependency issue

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
+          pak-version: devel # See https://github.com/r-lib/actions/issues/559
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests: testthat
 License: MIT
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.0
 Remotes:
     EDIorg/taxonomyCleanr
 URL: https://github.com/EDIorg/EMLassemblyline,

--- a/R/annotate_eml.R
+++ b/R/annotate_eml.R
@@ -407,7 +407,7 @@ annotate_eml <- function(
 #' elements only supported through ID references are added to 
 #' /eml/dataset/annotations (e.g. ResponsibleParty).
 #' 
-#' @keywords internal
+#' @keyword internal
 #' 
 annotate_element <- function(element, eml, anno, rp) {
   

--- a/R/annotate_eml.R
+++ b/R/annotate_eml.R
@@ -407,6 +407,8 @@ annotate_eml <- function(
 #' elements only supported through ID references are added to 
 #' /eml/dataset/annotations (e.g. ResponsibleParty).
 #' 
+#' @keywords internal
+#' 
 annotate_element <- function(element, eml, anno, rp) {
   
   if (element == "dataset") {

--- a/R/annotate_eml.R
+++ b/R/annotate_eml.R
@@ -407,7 +407,7 @@ annotate_eml <- function(
 #' elements only supported through ID references are added to 
 #' /eml/dataset/annotations (e.g. ResponsibleParty).
 #' 
-#' @keyword internal
+#' @keywords internal
 #' 
 annotate_element <- function(element, eml, anno, rp) {
   

--- a/man/annotate_element.Rd
+++ b/man/annotate_element.Rd
@@ -30,3 +30,4 @@ object annotations are retrieved and assigned to the EML. Annotatable
 elements only supported through ID references are added to 
 /eml/dataset/annotations (e.g. ResponsibleParty).
 }
+\keyword{internal}


### PR DESCRIPTION
This temporary fix resolves the failing website build and deployment to the gh-pages branch of the EMLassemblyline GitHub (GH) repository. This GH Action is defined in pkgdown.yml. More information on the fix is at https://github.com/r-lib/actions/issues/559.